### PR TITLE
Mark stale issues and pull requests: Fix #9041

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/close-stale-issues
+# https://github.com/actions/stale/blob/master/action.yml
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+on:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # stale-issue-message: 'Stale issue message'
+        # stale-issue-label: 'no-issue-activity'
+        stale-pr-message: 'This pull request seems to be stale and have no recent activities.  Are you still planning to work on it?  We will automatically close it in 30 days.'
+        stale-pr-label: 'stale'
+        days-before-stale: 30
+        days-before-close: 30


### PR DESCRIPTION
Mark stale issues and pull requests. PRs which have gone cold with no recent activities should be checked after 30 days and closed if no activity for another 30 days.

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a new Github Action to mark stale PRs and close them after 60 days of no activity.

## Other comments:

- We can do the same for issues. 
